### PR TITLE
Fix Typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ final disruptive class fdcFizzBuzzDelegator {
 ```
 E™ ast <file> // shows AST for Enterprise™ source file
 E™ compile <file> // compiles Enterprise™ source file to JS
-E™ ast <file> // evals Enterprise™ source file in NodeJS
+E™ eval <file> // evals Enterprise™ source file in NodeJS
 
 E™ ast <file> --turbo // the turbo option optimizes Enterprise™ code based on exclusive copyrighted technology
 ```


### PR DESCRIPTION
There was a small typo in the readme which had major impact on our critical enterprise business software.